### PR TITLE
Remove Active Support requirement for gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 *.gem
 /test/reports
+.idea/

--- a/lib/paisa.rb
+++ b/lib/paisa.rb
@@ -83,7 +83,7 @@ module Paisa
     when 3
       parts = []
       parts << [ONES[digits[0]], 'hundred'].join(' ')
-      parts << TENS.dig(*digits.slice(1, 2)) unless digits.slice(1, 2).sum.zero?
+      parts << TENS.dig(*digits.slice(1, 2)) unless digits.slice(1, 2).inject(0){|sum,x| sum + x }.zero?
       parts.join(' and ')
     else
       # do nothing


### PR DESCRIPTION
I cloned the repo and when try to run the test cases, one test case was failing because Array.sum() method require active support. Have made the change to use `ingest` to calculate sum instead. All test cases are passing now.

Also added IntelliJ Idea files to gitignore.